### PR TITLE
feat: Add form autofiller scripts and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+env/
+venv/
+ENV/
+pip-log.txt
+pip-delete-this-directory.txt
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.log
+*.pot
+*.mo
+
+# Operating System
+.DS_Store
+Thumbs.db
+Desktop.ini
+
+# Other
+coords.txt
+*.csv

--- a/README.md
+++ b/README.md
@@ -1,1 +1,126 @@
-# form_autofill
+# Form Filler Bot
+
+This project consists of two main components:
+1.  A Linux shell script (`get_coords.sh`) to capture screen coordinates for form fields and buttons.
+2.  A Python application (`form_filler.py`) that reads data from a CSV file and uses the captured coordinates to automatically fill and submit web forms or other GUI applications.
+
+## Features
+
+-   **Coordinate Capturing:** Interactively capture X,Y coordinates for any element on your screen.
+-   **CSV Data Input:** Reads data from a CSV file, with the first row expected to be headers.
+-   **Automated Form Filling:** Uses `pyautogui` to simulate mouse movements, clicks, and typing.
+-   **Configurable Delays:** Allows adjustment of delays between actions to suit different system speeds and application responsiveness.
+-   **Command-line Interface:** Both scripts are run from the command line.
+
+## Prerequisites
+
+-   **Linux Environment:** The `get_coords.sh` script is designed for Linux.
+-   **xdotool:** Required by `get_coords.sh` for capturing mouse coordinates.
+    -   Installation (Debian/Ubuntu): `sudo apt update && sudo apt install xdotool`
+-   **Python 3:** Required to run `form_filler.py`.
+-   **pip (Python package installer):** Usually comes with Python 3.
+-   **Python Libraries:**
+    -   `pyautogui`: For GUI automation.
+    -   The `csv` module used is part of the Python standard library.
+
+    Install Python libraries using pip:
+    ```bash
+    pip install pyautogui
+    ```
+    *(Note: `pyautogui` might have other system-level dependencies depending on your Linux distribution for interacting with the display server, e.g., `scrot`, `python3-tk`, `python3-dev`. The `form_filler.py` script will mention these if an `ImportError` for `pyautogui` occurs. If `pyautogui` fails during execution, check its documentation for specific OS dependencies like those needed for X11/Wayland.)*
+
+## Setup and Usage
+
+### 1. Capture Coordinates (`get_coords.sh`)
+
+This script will help you create a `coords.txt` file containing the screen positions of your form fields and the final submit/action button.
+
+a.  **Make the script executable:**
+    ```bash
+    chmod +x get_coords.sh
+    ```
+
+b.  **Run the script:**
+    ```bash
+    ./get_coords.sh
+    ```
+
+c.  **Follow the on-screen prompts:**
+    -   The script will ask you to enter a name for each coordinate (e.g., `username`, `email_field`, `submit_button`).
+    -   After entering a name, you will have 5 seconds to move your mouse cursor to the desired location on the screen.
+    -   The script will capture the X and Y coordinates and save them with the name you provided to `coords.txt`.
+    -   Enter `done` when you have captured all necessary coordinates.
+
+    **Example `coords.txt`:**
+    ```
+    firstname:850,350
+    lastname:850,400
+    email:850,450
+    submit_button:900,520
+    ```
+    **Important:** The names you give here (except for the submit button) **must match** the headers in your CSV file.
+
+### 2. Prepare Your CSV Data File
+
+Create a CSV file (e.g., `data.csv`) where:
+-   The first row contains headers. These headers **must match the names** you assigned to the coordinates in `coords.txt` (e.g., if you used `firstname` in `coords.txt`, your CSV should have a `firstname` column).
+-   Subsequent rows contain the data to be filled into the form.
+
+**Example `data.csv`:**
+```csv
+firstname,lastname,email
+John,Doe,john.doe@example.com
+Jane,Smith,jane.smith@example.com
+```
+
+### 3. Run the Form Filler (`form_filler.py`)
+
+This Python script reads your `coords.txt` and your CSV file, then automates the form filling process.
+
+a.  **Open the target application/web page** that you want to fill.
+
+b.  **Run the script from your terminal:**
+    ```bash
+    python3 form_filler.py your_data.csv --submit-button-name your_submit_button_name
+    ```
+    -   Replace `your_data.csv` with the path to your CSV file.
+    -   Replace `your_submit_button_name` with the exact name you gave to your submit/action button in `get_coords.sh` (e.g., `submit_button`).
+
+c.  **Switch to the target application window quickly!** The script has a short delay (3 seconds by default after starting) before it begins controlling your mouse and keyboard.
+
+**Command-line Arguments for `form_filler.py`:**
+-   `csv_file`: (Required) Path to your CSV data file.
+-   `--coords-file COORDS_FILE` or `--coords_file COORDS_FILE`: (Optional) Path to your coordinates file. Defaults to `coords.txt` in the same directory.
+-   `--delay DELAY`: (Optional) Delay in seconds between GUI actions. Default is `0.5`.
+-   `--submit-button-name SUBMIT_BUTTON_NAME` or `--submit_button_name SUBMIT_BUTTON_NAME`: (Required) The name of the submit button as defined in your coordinates file.
+
+**Example Usage:**
+```bash
+python3 form_filler.py data.csv --submit-button-name submit_button --delay 0.7
+```
+*(Note: The script `form_filler.py` uses `argparse`, which typically allows both `-` and `_` in argument names, so `--submit-button-name` and `--submit_button_name` should both work, as should `--coords-file` and `--coords_file`.)*
+
+## How It Works
+
+1.  `get_coords.sh` uses `xdotool getmouselocation --shell` to find out where your mouse is pointing after a timed delay. It stores these named coordinates.
+2.  `form_filler.py` parses the coordinate file and the CSV file.
+3.  For each row in the CSV:
+    -   It iterates through the CSV headers.
+    -   For each header, it looks up the corresponding coordinate.
+    -   It uses `pyautogui` to move the mouse to that coordinate, click, and type the data from the CSV cell.
+    -   After processing all data cells in a row, it clicks the designated submit button's coordinates.
+
+## Troubleshooting
+
+-   **Incorrect Coordinates:** If the mouse isn't clicking the right places, re-run `get_coords.sh` carefully. Ensure your application window doesn't move or resize between capturing coordinates and running the filler.
+-   **`pyautogui` Issues:**
+    -   **FailSafeException:** If `pyautogui` throws a `FailSafeException`, it means you moved your mouse to a corner of the screen (usually top-left) as a security measure to stop the script. The script is designed to catch this and exit gracefully.
+    -   **Permissions/Display Server:** On some Linux systems, `pyautogui` might need additional permissions or specific configurations to control the mouse and keyboard. This is especially true under Wayland (try running in an X11 session if issues persist). Refer to `pyautogui` documentation and the installation notes in `form_filler.py`.
+    -   **Module Not Found:** Ensure `pyautogui` is installed in the Python environment you are using. (`pip install pyautogui`).
+-   **Timing Issues:** If the script is too fast or too slow for your target application, adjust the `--delay` option in `form_filler.py`. Some applications need more time to process inputs or load new sections.
+-   **Window Focus:** Ensure the target application window is active and focused before `form_filler.py` starts its automation sequence. The script includes a brief pause at the beginning for this. If the wrong window is active, the script will interact with that window instead.
+-   **`xdotool` not found/not working:** Ensure `xdotool` is installed correctly and working from your terminal. If `get_coords.sh` reports errors capturing coordinates, this is the likely cause.
+
+## License
+This project is licensed under the MIT License. You can create a `LICENSE` file and paste the MIT License text into it if you wish.
+(A basic MIT License template can be found at https://opensource.org/licenses/MIT)

--- a/form_filler.py
+++ b/form_filler.py
@@ -1,0 +1,181 @@
+# form_filler.py
+# This script automates filling web forms using coordinates and CSV data.
+#
+# Installation for pyautogui (if not installed):
+# pip install pyautogui
+#
+# On Linux, you might also need to install scrot for screenshots (used by pyautogui internally sometimes)
+# and xclip or xsel for copy/paste functionality:
+# sudo apt-get install scrot python3-tk python3-dev
+# sudo apt-get install xclip # or xsel
+
+import csv
+import argparse
+import time
+import os
+
+try:
+    import pyautogui
+except ImportError:
+    print("Error: pyautogui library is not installed.")
+    print("Please install it by running: pip install pyautogui")
+    print("On Linux, you may also need: sudo apt-get install scrot python3-tk python3-dev xclip")
+    exit(1)
+
+def parse_coordinates(coords_filepath: str) -> dict:
+    """
+    Parses a coordinates file (e.g., coords.txt) into a dictionary.
+
+    Args:
+        coords_filepath: Path to the coordinates file.
+                         Each line should be in the format: name:X,Y
+
+    Returns:
+        A dictionary mapping names to (X, Y) integer tuples.
+        Example: {'username_field': (150, 300), 'submit_button': (200, 400)}
+
+    Raises:
+        FileNotFoundError: If the coordinates file does not exist.
+    """
+    if not os.path.exists(coords_filepath):
+        raise FileNotFoundError(f"Error: Coordinates file not found at '{coords_filepath}'")
+
+    coordinates_map = {}
+    try:
+        with open(coords_filepath, 'r') as f:
+            for line_num, line in enumerate(f, 1):
+                line = line.strip()
+                if not line or line.startswith('#'):  # Skip empty lines or comments
+                    continue
+                parts = line.split(':', 1)
+                if len(parts) != 2:
+                    print(f"Warning: Skipping malformed line {line_num} in '{coords_filepath}': '{line}' - missing ':' separator.")
+                    continue
+                name = parts[0].strip()
+                coords_str = parts[1].strip()
+                try:
+                    x_str, y_str = coords_str.split(',')
+                    x = int(x_str.strip())
+                    y = int(y_str.strip())
+                    coordinates_map[name] = (x, y)
+                except ValueError:
+                    print(f"Warning: Skipping malformed coordinate format on line {line_num} in '{coords_filepath}': '{line}'")
+    except Exception as e:
+        print(f"Error reading or parsing coordinates file '{coords_filepath}': {e}")
+        # Potentially re-raise or return empty dict depending on desired strictness
+        return {} # Return empty/partial map on error
+    return coordinates_map
+
+def read_csv_data(csv_filepath: str) -> list:
+    """
+    Reads data from a CSV file into a list of dictionaries.
+
+    Args:
+        csv_filepath: Path to the CSV file.
+                      The first row is assumed to be headers.
+
+    Returns:
+        A list of dictionaries, where each dictionary represents a row
+        (header: value).
+
+    Raises:
+        FileNotFoundError: If the CSV file does not exist.
+    """
+    if not os.path.exists(csv_filepath):
+        raise FileNotFoundError(f"Error: CSV file not found at '{csv_filepath}'")
+
+    data_rows = []
+    try:
+        with open(csv_filepath, mode='r', encoding='utf-8-sig') as csvfile: # utf-8-sig handles BOM
+            reader = csv.DictReader(csvfile)
+            for row in reader:
+                data_rows.append(row)
+    except Exception as e:
+        print(f"Error reading CSV file '{csv_filepath}': {e}")
+        return [] # Return empty list on error
+    return data_rows
+
+def main():
+    """
+    Main function to parse arguments, load data, and run GUI automation.
+    """
+    parser = argparse.ArgumentParser(description="Automate form filling using mouse coordinates and CSV data.")
+    parser.add_argument("csv_file", help="Path to the input CSV file (required).")
+    parser.add_argument("--coords_file", default="coords.txt",
+                        help="Path to the coordinates file (default: coords.txt).")
+    parser.add_argument("--delay", type=float, default=0.5,
+                        help="Delay in seconds between pyautogui actions (default: 0.5).")
+    parser.add_argument("--submit_button_name", required=True,
+                        help="The name of the submit button as defined in the coordinates file (e.g., 'submit_button').")
+
+    args = parser.parse_args()
+
+    try:
+        print(f"Loading coordinates from: {args.coords_file}")
+        coordinates_map = parse_coordinates(args.coords_file)
+        if not coordinates_map:
+            print("No coordinates were loaded. Exiting.")
+            return
+
+        print(f"Loading CSV data from: {args.csv_file}")
+        form_data_rows = read_csv_data(args.csv_file)
+        if not form_data_rows:
+            print("No data loaded from CSV file. Exiting.")
+            return
+
+    except FileNotFoundError as e:
+        print(e)
+        return
+    except Exception as e: # Catch any other unexpected errors during setup
+        print(f"An unexpected error occurred during setup: {e}")
+        return
+
+    # --- GUI Automation ---
+    print("\nStarting GUI automation process...")
+    print("IMPORTANT: Please do not move the mouse or use the keyboard during automation!")
+    print("You have 3 seconds to switch to the target window...")
+    time.sleep(3) # Give user time to switch to the target window
+
+    submit_coords = coordinates_map.get(args.submit_button_name)
+    if not submit_coords:
+        print(f"Error: Submit button name '{args.submit_button_name}' not found in coordinates file. Exiting.")
+        return
+
+    for i, row in enumerate(form_data_rows):
+        print(f"\nProcessing row {i+1}/{len(form_data_rows)}: {row}")
+        try:
+            for header, value in row.items():
+                if header in coordinates_map:
+                    x, y = coordinates_map[header]
+                    print(f"  Filling field '{header}' at ({x},{y}) with value '{value}'")
+                    pyautogui.moveTo(x, y, duration=0.2)
+                    pyautogui.click()
+                    time.sleep(args.delay / 2) # Short sleep after click
+                    pyautogui.typewrite(str(value), interval=0.05) # Type with small interval
+                    time.sleep(args.delay)
+                else:
+                    print(f"  Warning: No coordinate found for field '{header}'. Skipping.")
+
+            # Click the submit button for the current row
+            print(f"  Clicking submit button '{args.submit_button_name}' at ({submit_coords[0]},{submit_coords[1]})")
+            pyautogui.moveTo(submit_coords[0], submit_coords[1], duration=0.2)
+            pyautogui.click()
+            print("  Submit button clicked.")
+            time.sleep(args.delay * 2) # Longer sleep after submit
+
+        except pyautogui.FailSafeException:
+            print("\nFAIL-SAFE TRIGGERED! PyAutoGUI mouse movement to a corner of the screen was detected.")
+            print("Automation stopped to prevent unintended actions.")
+            return
+        except Exception as e:
+            print(f"An error occurred during PyAutoGUI actions for row {i+1}: {e}")
+            print("Skipping to the next row if possible, or stopping if critical.")
+            # Depending on the error, you might want to 'continue' or 'return'
+            # For now, let's stop on any pyautogui error to be safe
+            return
+
+
+    print("\nAutomation complete for all rows.")
+
+if __name__ == "__main__":
+    main()

--- a/get_coords.sh
+++ b/get_coords.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Output file
+OUTPUT_FILE="coords.txt"
+
+# Welcome message and instructions
+echo "Welcome to the Coordinate Generation Script!"
+echo "This script will help you capture mouse coordinates for various points on your screen."
+echo "Instructions:"
+echo "1. Make sure you have 'xdotool' installed. If not, please install it (e.g., sudo apt-get install xdotool)."
+echo "2. When prompted, enter a descriptive name for the coordinate (e.g., 'username_field', 'login_button')."
+echo "3. After entering the name, you will have 5 seconds to position your mouse over the desired element."
+echo "4. The script will then capture the mouse coordinates (X,Y)."
+echo "5. Enter 'done' or 'exit' as the name when you are finished capturing coordinates."
+echo "The coordinates will be saved to '$OUTPUT_FILE'."
+echo ""
+
+# Clear the output file if it already exists
+> "$OUTPUT_FILE"
+echo "Cleared existing '$OUTPUT_FILE'."
+echo ""
+
+# Loop to capture coordinates
+while true; do
+  read -p "Enter a name for the coordinate (or 'done' to finish): " coord_name
+
+  # Check if the user wants to exit
+  if [[ "$coord_name" == "done" || "$coord_name" == "exit" ]]; then
+    break
+  fi
+
+  # Prompt user to position mouse and wait
+  echo "Position your mouse over the '$coord_name' element. Capturing in 5 seconds..."
+  sleep 5
+
+  # Get mouse location using xdotool and parse X, Y
+  MOUSE_INFO=$(xdotool getmouselocation --shell)
+  X=$(echo "$MOUSE_INFO" | grep 'X=' | cut -d'=' -f2)
+  Y=$(echo "$MOUSE_INFO" | grep 'Y=' | cut -d'=' -f2)
+
+  # Check if X and Y were captured
+  if [[ -z "$X" || -z "$Y" ]]; then
+    echo "Error: Could not capture mouse coordinates. Make sure xdotool is working correctly."
+    echo "If you are running this in a headless environment or via SSH without X forwarding, xdotool may not work."
+    continue # Skip to the next iteration
+  fi
+
+  # Append to the output file
+  echo "${coord_name}:${X},${Y}" >> "$OUTPUT_FILE"
+  echo "Saved: ${coord_name} at X=${X}, Y=${Y} to '$OUTPUT_FILE'."
+  echo ""
+done
+
+# Final message
+echo ""
+echo "Coordinate capturing complete."
+echo "All coordinates have been saved to '$OUTPUT_FILE'."
+echo "You can now use this file for your automation scripts."


### PR DESCRIPTION
This commit introduces a set of tools to automate form filling:

1.  `get_coords.sh`: A Linux shell script that allows you to capture screen coordinates for form elements and a submit button using `xdotool`. The coordinates are saved to a `coords.txt` file.

2.  `form_filler.py`: A Python application that reads data from a user-provided CSV file and the `coords.txt` file. It then uses `pyautogui` to simulate mouse movements and keyboard input to fill the form fields and click the submit button for each row of data in the CSV.

3.  `README.md`: Comprehensive documentation detailing prerequisites, setup, usage instructions for both scripts, how it works, and troubleshooting tips.

4.  `.gitignore`: Standard Python and OS ignores, plus `coords.txt` and `*.csv` to prevent committing user-specific data.

The scripts are designed to be configurable (e.g., file paths, delays) via command-line arguments. Error handling for file operations and GUI automation safety (FailSafeException) has been included.